### PR TITLE
Add Action Button Support in Toast

### DIFF
--- a/lib/common/toast/animated_toast.dart
+++ b/lib/common/toast/animated_toast.dart
@@ -14,6 +14,8 @@ void showAnimatedToast({
   Color? textColor,
   IconData? customIcon,
   double borderRadius = 12.0,
+  String? actionText,
+  VoidCallback? onActionTap,
   Duration duration = const Duration(seconds: 3),
 }) {
   _currentToast?.remove();
@@ -28,6 +30,8 @@ void showAnimatedToast({
       textColor: textColor,
       customIcon: customIcon,
       borderRadius: borderRadius,
+      actionText: actionText,
+      onActionTap: onActionTap,
       duration: duration,
     ),
   );
@@ -51,6 +55,8 @@ class _AnimatedToast extends StatefulWidget {
   final Color? textColor;
   final IconData? customIcon;
   final double borderRadius;
+  final String? actionText;
+  final VoidCallback? onActionTap;
   final Duration duration;
 
   const _AnimatedToast({
@@ -62,6 +68,8 @@ class _AnimatedToast extends StatefulWidget {
     this.textColor,
     this.customIcon,
     this.borderRadius = 12.0,
+    this.actionText,
+    this.onActionTap,
     required this.duration,
   }) : super(key: key);
 
@@ -190,6 +198,17 @@ class _AnimatedToastState extends State<_AnimatedToast> with SingleTickerProvide
                       style: TextStyle(color: widget.textColor ?? Colors.white),
                     ),
                   ),
+                  if (widget.actionText != null && widget.onActionTap != null)
+                    TextButton(
+                      onPressed: widget.onActionTap,
+                      child: Text(
+                        widget.actionText!,
+                        style: TextStyle(
+                          color: widget.textColor ?? Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
                 ],
               ),
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,7 +30,7 @@ class ToastDemoPage extends StatelessWidget {
     );
   }
 
-  void _showTopToast(BuildContext context) {
+  void _showTopWarningToast(BuildContext context) {
     showAnimatedToast(
       context: context,
       message: "This is a WARNING message at TOP!",
@@ -52,16 +52,17 @@ class ToastDemoPage extends StatelessWidget {
     );
   }
 
-  void _showBottomErrorToast(BuildContext context) {
+  void _showErrorWithActionToast(BuildContext context) {
     showAnimatedToast(
       context: context,
-      message: "This is an ERROR toast at BOTTOM!",
+      message: "Item deleted",
       type: ToastType.error,
-      position: ToastPosition.bottom,
-      backgroundColor: Colors.black,
-      textColor: Colors.redAccent,
-      customIcon: Icons.warning,
-      borderRadius: 30,
+      actionText: "UNDO",
+      onActionTap: () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text("Undo tapped!")),
+        );
+      },
     );
   }
 
@@ -79,7 +80,7 @@ class ToastDemoPage extends StatelessWidget {
               child: const Text('DEFAULT SUCCESS'),
             ),
             ElevatedButton(
-              onPressed: () => _showTopToast(context),
+              onPressed: () => _showTopWarningToast(context),
               child: const Text('TOP WARNING'),
             ),
             ElevatedButton(
@@ -87,8 +88,8 @@ class ToastDemoPage extends StatelessWidget {
               child: const Text('CENTER CUSTOM'),
             ),
             ElevatedButton(
-              onPressed: () => _showBottomErrorToast(context),
-              child: const Text('BOTTOM ERROR'),
+              onPressed: () => _showErrorWithActionToast(context),
+              child: const Text('ERROR WITH ACTION'),
             ),
           ],
         ),


### PR DESCRIPTION
- Added actionText and onActionTap parameters
- Displays a clickable action button inside the toast if provided
- Supports full styling along with position and theme support\n- Improved flexibility for use cases like Undo/Retry actions